### PR TITLE
[DO NOT MERGE]update makefile to add sbom.spdx file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ endif
 SUBDIRS += tests
 SUBDIRS += tests/unity_tests
 
-dist_doc_DATA = README.md CONTRIBUTING.md AUTHORS CHANGES
+dist_doc_DATA = README.md CONTRIBUTING.md AUTHORS CHANGES sbom.spdx
 
 # XXX - get around our default non-prefix-preserving paths for distcheck
 DISTCHECK_CONFIGURE_FLAGS = --sysconfdir='$${prefix}/etc/duo'


### PR DESCRIPTION
## Issue number being addressed
Fixes #
D

## Summary of the change
In ci there will be a sbom file generated. This PR is to add the sbom file into the final tar file.

Currently it will break for local dev because the sbom will be missing.

## Test Plan
Tested locally by `touch sbom.spdx`
